### PR TITLE
Indexer implements IReadOnlyDictionary. 

### DIFF
--- a/BidirectionalMap.PropertyTests/Tests.fs
+++ b/BidirectionalMap.PropertyTests/Tests.fs
@@ -42,4 +42,10 @@ let ``Top-level as set equals forward set`` (mapVals) =
     let map = new BiMap<int, Guid>(mapVals)
     map |= map.Forward
 
+[<Property>]
+let ``Indexer Count matches number of unique pairs`` (mapVals) =
+    let map = new BiMap<int, Guid>(mapVals)
+    map.Forward.Count = Seq.length mapVals
+    && map.Reverse.Count = Seq.length mapVals
+
 // ?? after remove, neither set contains the key??

--- a/BidirectionalMap.Tests/BiMapTests.cs
+++ b/BidirectionalMap.Tests/BiMapTests.cs
@@ -287,8 +287,34 @@ namespace BidirectionalMap.Tests
         }
 
 
+        [Fact]
+        public void GetValueOrDefault_Extension_Method_Works()
+        {
+            // This test is not strictly necessary, as we are already testing the TryGet method. But it documents the expected behavior of the extension method.
+
+            var map = new BiMap<int, string>
+            {
+                {1, "one"},
+                {2, "two"}
+            };
+
+            // Test values that exist
+            Assert.Equal("one", map.Forward.GetValueOrDefault(1));
+            Assert.Equal("two", map.Forward.GetValueOrDefault(2));
+            Assert.Equal(1, map.Reverse.GetValueOrDefault("one"));
+            Assert.Equal(2, map.Reverse.GetValueOrDefault("two"));
+
+            // Test values that don't exist - should return default(TValue) which is null for reference types and default value for value types
+            Assert.Null(map.Forward.GetValueOrDefault(3));
+            Assert.Equal(0, map.Reverse.GetValueOrDefault("three"));
+
+            // Test values that don't exist with custom default value
+            Assert.Equal("default", map.Forward.GetValueOrDefault(3, "default"));
+            Assert.Equal(42, map.Reverse.GetValueOrDefault("three", 42));
+        }
+
         //NOTE: Property tests move to F# for easier value-based equality and fluent property definition
 
-        
+
     }
 }

--- a/BidirectionalMap/BiMap.cs
+++ b/BidirectionalMap/BiMap.cs
@@ -103,9 +103,9 @@ namespace BidirectionalMap
         /// </summary>
         /// <typeparam name="Key"></typeparam>
         /// <typeparam name="Value"></typeparam>
-        public class Indexer<Key, Value> : IEnumerable<KeyValuePair<Key, Value>>
+        public class Indexer<Key, Value> : IReadOnlyDictionary<Key, Value>
         {
-            private IDictionary<Key, Value> _dictionary;
+            private readonly IDictionary<Key, Value> _dictionary;
 
             public Indexer()
             {
@@ -131,6 +131,11 @@ namespace BidirectionalMap
                 get { return _dictionary[index]; }
             }
 
+            public int Count
+            {
+                get { return _dictionary.Count; }
+            }
+
             public static implicit operator Dictionary<Key, Value>(Indexer<Key, Value> indexer)
             {
                 return new Dictionary<Key, Value>(indexer._dictionary);
@@ -151,11 +156,6 @@ namespace BidirectionalMap
             internal bool Remove(Key key)
             {
                 return _dictionary.Remove(key);
-            }
-
-            internal int Count()
-            {
-                return _dictionary.Count;
             }
 
             public bool ContainsKey(Key key)

--- a/BidirectionalMap/BiMap.cs
+++ b/BidirectionalMap/BiMap.cs
@@ -101,32 +101,32 @@ namespace BidirectionalMap
         /// <summary>
         /// Publicly read-only lookup to prevent inconsistent state between forward and reverse map lookups
         /// </summary>
-        /// <typeparam name="Key"></typeparam>
-        /// <typeparam name="Value"></typeparam>
-        public class Indexer<Key, Value> : IReadOnlyDictionary<Key, Value>
+        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TValue"></typeparam>
+        public class Indexer<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
         {
-            private readonly IDictionary<Key, Value> _dictionary;
+            private readonly IDictionary<TKey, TValue> _dictionary;
 
             public Indexer()
             {
-                _dictionary = new Dictionary<Key, Value>();
+                _dictionary = new Dictionary<TKey, TValue>();
             }
 
-            public Indexer(IDictionary<Key, Value> dictionary)
+            public Indexer(IDictionary<TKey, TValue> dictionary)
             {
                 _dictionary = dictionary;
             }
-            public Indexer(IEqualityComparer<Key> comparer)
+            public Indexer(IEqualityComparer<TKey> comparer)
             {
-                _dictionary = new Dictionary<Key, Value>(comparer);
+                _dictionary = new Dictionary<TKey, TValue>(comparer);
             }
 
-            public Indexer(IDictionary<Key, Value> dictionary, IEqualityComparer<Key> comparer)
+            public Indexer(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer)
             {
-                _dictionary = new Dictionary<Key, Value>(dictionary, comparer ?? EqualityComparer<Key>.Default);
+                _dictionary = new Dictionary<TKey, TValue>(dictionary, comparer ?? EqualityComparer<TKey>.Default);
             }
 
-            public Value this[Key index]
+            public TValue this[TKey index]
             {
                 get { return _dictionary[index]; }
             }
@@ -136,39 +136,39 @@ namespace BidirectionalMap
                 get { return _dictionary.Count; }
             }
 
-            public static implicit operator Dictionary<Key, Value>(Indexer<Key, Value> indexer)
+            public static implicit operator Dictionary<TKey, TValue>(Indexer<TKey, TValue> indexer)
             {
-                return new Dictionary<Key, Value>(indexer._dictionary);
+                return new Dictionary<TKey, TValue>(indexer._dictionary);
             }
 
-            internal void Add(Key key, Value value)
+            internal void Add(TKey key, TValue value)
             {
                 _dictionary.Add(key, value);
             }
 
-            internal bool TryAdd(Key key, Value value)
+            internal bool TryAdd(TKey key, TValue value)
             {
                 if (_dictionary.ContainsKey(key)) return false;
                 _dictionary.Add(key, value);
                 return true;
             }
 
-            internal bool Remove(Key key)
+            internal bool Remove(TKey key)
             {
                 return _dictionary.Remove(key);
             }
 
-            public bool ContainsKey(Key key)
+            public bool ContainsKey(TKey key)
             {
                 return _dictionary.ContainsKey(key);
             }
 
-            public bool TryGetValue(Key key, out Value value)
+            public bool TryGetValue(TKey key, out TValue value)
             {
                 return _dictionary.TryGetValue(key, out value);
             }
 
-            public IEnumerable<Key> Keys
+            public IEnumerable<TKey> Keys
             {
                 get
                 {
@@ -176,7 +176,7 @@ namespace BidirectionalMap
                 }
             }
 
-            public IEnumerable<Value> Values
+            public IEnumerable<TValue> Values
             {
                 get
                 {
@@ -188,12 +188,12 @@ namespace BidirectionalMap
             /// Deep copy lookup as a dictionary
             /// </summary>
             /// <returns></returns>
-            public Dictionary<Key, Value> ToDictionary()
+            public Dictionary<TKey, TValue> ToDictionary()
             {
-                return new Dictionary<Key, Value>(_dictionary);
+                return new Dictionary<TKey, TValue>(_dictionary);
             }
 
-            public IEnumerator<KeyValuePair<Key, Value>> GetEnumerator()
+            public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
             {
                 return _dictionary.GetEnumerator();
             }


### PR DESCRIPTION
Changed the indexer to implement `IReadOnlyDictionary<TKey, TValue>` instead of `IEnumerable<KeyValuePair<TKey, TValue>>`. 
- Note, `IReadOnlyDictionary` inherits from `IEnumerable`, so no functionality is lost.
- Renamed generic type parameters for Indexer to `TKey` and `TValue` to fix code style warnings.
- Changed `Count()` method to a property as required to implement `IReadOnlyDictionary`.
- Added test to the FSharp property unit tests for the Count property.
- Added unit test for `GetValueOrDefault`. This is not strictly necessary but added it since this is the desired feature that drove this change.

Resolves Issue #12

